### PR TITLE
Potential fix for code scanning alert no. 6: Code injection

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import os
 import sys
+import json
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request, render_template, abort
 from flask_cors import CORS
@@ -77,9 +78,9 @@ def getUserFromQuery(query):
 	user = user.replace('true', 'True').replace('false', 'False')
 	
 	try:
-		# Safely parse the string into a dictionary or list (avoiding eval)
-		user = eval(user, {"__builtins__": None}, {})
-	except (SyntaxError, ValueError):
+		# Safely parse the string into a dictionary or list using json.loads
+		user = json.loads(user)
+	except (json.JSONDecodeError, ValueError):
 		return None
 	return user
 


### PR DESCRIPTION
Potential fix for [https://github.com/LightYagami28/TagEveryoneTelegramBot/security/code-scanning/6](https://github.com/LightYagami28/TagEveryoneTelegramBot/security/code-scanning/6)

To fix the problem, we should avoid using `eval` to parse the `user` string. Instead, we can use a safer method to parse the string into a dictionary or list. One approach is to use the `json` module to parse the string, as it is designed to handle JSON data safely.

- Replace the `eval` function with `json.loads` to parse the `user` string.
- Ensure that the `user` string is properly formatted as JSON before parsing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
